### PR TITLE
components in example need mustaches

### DIFF
--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,13 +1,13 @@
-<ion-header kind="light">Header</ion-header>
-<ion-content header=true footer=true>
-  <ion-button block=true>ohai</ion-button>
-  <ion-list>
-    <ion-item checkbox=true>
-      <ion-checkbox></ion-checkbox> Flux Capacitor
-    </ion-item>
-    <ion-item toggle=true>
-      Web Components <ion-toggle/>
-    </ion-item>
+{{#ion-header kind="positive"}}Header{{/ion-header}}
+{{#ion-content header=true footer=true}}
+  {{#ion-button block=true}}ohai{{/ion-button}}
+  {{#ion-list}}
+    {{#ion-item checkbox=true}}
+      {{#ion-checkbox}}{{/ion-checkbox}} Flux Capacitor
+    {{/ion-item}}
+    {{#ion-item toggle=true}}
+      Web Components {{ion-toggle}}
+    {{/ion-item}}
 
     <a class="item item-icon-left item-icon-right" href="#">
       {{ion-icon "chatbubble-working"}}
@@ -15,10 +15,10 @@
       {{ion-icon "chatbubble-working"}}
     </a>
     {{#each model.items as |item|}}
-      <ion-list-item>
+      {{#ion-list-item}}
         {{item}}
-      </ion-list-item>
+      {{/ion-list-item}}
     {{/each}}
-  </ion-list>
-</ion-content>
-<ion-footer kind="light">Footer</ion-footer>
+  {{/ion-list}}
+{{/ion-content}}
+{{#ion-footer kind="light"}}Footer{{/ion-footer}}


### PR DESCRIPTION
I tried using the example code in an app and nothing was rendering appropriately.  

the`<ion-header>` should be in mustaches  `{{ion-header}}` , etc....

i know there is plans for ember to support just normal html tag syntax, but shouldn't the example be what works today?
